### PR TITLE
fix: look for paths in compilerOptions

### DIFF
--- a/index.test.tsx
+++ b/index.test.tsx
@@ -1,13 +1,13 @@
 import { resolve } from "path"
-import convertPathsToAliases from "./index"
+import convertPathsToAliases, { TsconfigFile } from "./index"
 
 it("it converts single file", () => {
-  const tsConfig = {
+  const tsConfig = getTsConfig({
     baseUrl: "./src",
     paths: {
       Utils: ["utils.tsx"]
     }
-  }
+  })
   const expected = {
     Utils: resolve("src", "utils.tsx")
   }
@@ -17,12 +17,12 @@ it("it converts single file", () => {
 })
 
 it("it converts directory", () => {
-  const tsConfig = {
+  const tsConfig = getTsConfig({
     baseUrl: ".",
     paths: {
       "Actions/*": ["actions/*"]
     }
-  }
+  })
   const expected = {
     Actions: resolve("actions")
   }
@@ -30,13 +30,13 @@ it("it converts directory", () => {
 })
 
 it("it converts multiple paths", () => {
-  const tsConfig = {
+  const tsConfig = getTsConfig({
     baseUrl: ".",
     paths: {
       "Actions/*": ["actions/*"],
       Utils: ["utils.tsx"]
     }
-  }
+  })
   const expected = {
     Actions: resolve("actions"),
     Utils: resolve("utils.tsx")
@@ -45,15 +45,23 @@ it("it converts multiple paths", () => {
 })
 
 it("it works with optional param dirname", () => {
-  const tsConfig = {
+  const tsConfig = getTsConfig({
     baseUrl: "src",
     paths: {
       "Helpers/*": ["../helpers/*"]
     }
-  }
+  })
   const dirname = resolve(__dirname, "general")
   const expected = {
     Helpers: resolve(__dirname, "general", "helpers")
   }
   expect(convertPathsToAliases(tsConfig, dirname)).toEqual(expected)
 })
+
+function getTsConfig(
+  compilerOptions: TsconfigFile["compilerOptions"]
+): TsconfigFile {
+  return {
+    compilerOptions
+  }
+}

--- a/index.tsx
+++ b/index.tsx
@@ -1,9 +1,11 @@
 import { resolve } from "path"
 
-type TsconfigFile = {
-  baseUrl: string
-  paths: {
-    [aliasName: string]: string[]
+export interface TsconfigFile {
+  compilerOptions: {
+    baseUrl: string
+    paths: {
+      [aliasName: string]: string[]
+    }
   }
 }
 
@@ -15,7 +17,7 @@ const replaceGlobs = (path: string): string =>
   path.replace(/(\/\*\*)*\/\*$/, "")
 
 export default (tsconfigFile: TsconfigFile, dirname = "."): WebpackAliases => {
-  const { baseUrl, paths } = tsconfigFile
+  const { baseUrl, paths } = tsconfigFile.compilerOptions
   return Object.keys(paths).reduce((aliases: WebpackAliases, pathName) => {
     const alias = replaceGlobs(pathName)
     const path = replaceGlobs(paths[pathName][0])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-tsconfig-paths-to-webpack-aliases",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "main": "index.js",
   "author": "marzelin <marzelin@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
closes https://github.com/marzelin/convert-tsconfig-paths-to-webpack-aliases/issues/1